### PR TITLE
[TECH-14697] Android soft keyboard fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lendinghome/react-number-format-input",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "An input for numbers formatted by Intl.NumberFormat.",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",

--- a/src/abstract-number-format-input/index.js
+++ b/src/abstract-number-format-input/index.js
@@ -109,9 +109,9 @@ export default function createAbstractNumberFormatInput(numberFormat) {
     return {selection: {start: position, end: position}, value: nextValue, preventDefault, stopPropagation, clipboardText};
   }
 
-  function handleKeyPress({charCode, metaKey, altKey, ctrlKey, selection, value, maxLength}) {
+  function handleKeyPress({charData, charCode, metaKey, altKey, ctrlKey, selection, value, maxLength}) {
     const {start, end} = selection;
-    const char = String.fromCharCode(charCode);
+    const char = charCode !== undefined ? String.fromCharCode(charCode) : charData;
     const oldValue = parse(value);
     let nextValue = oldValue;
     let [preventDefault, stopPropagation] = [false, false];


### PR DESCRIPTION
Currently the number format input will not accept input from any android device (through the software tap keyboard).

Android software keyboards do not fire a `keypress` event--the keypress event actually being [deprecated in the W3C Dom Level 3 Spec](https://www.w3.org/TR/DOM-Level-3-Events/#event-type-keypress). The software keyboards _do_ first a `beforeinput` event which, while a little different, can be mapped to a keypress handler. These events pass in a string representing the data to be added to the input (or the empty string for delete?) -- this does not include any modifier keys afaik...but they aren't needed in the context of a software keyboard.

I also had to update the code that keeps the cursor in the correct position, since this event fires before the UI updates and we need to allow it to catch up before setting selection ranges.

**OUTSTANDING ISSUES**
* No detection of support for the `beforeinput` is performed--this heavily relies on the fact that no browser will implement both keypress and beforeinput events that respond to the same action. Still, things appear to work fine in a variety of browsers.
* Hitting delete will delete the entire fields content. I haven't look into it, but it may be an issue with the keydown handler fielding it incorrectly (keydown events are still triggered on the software keyboards, though I don't think they have the correct char code, but rather the same three digit code for every key pressed indicating some kind of keyboard buffer in use something or other)

**Final thought(s)**
* I made a quick attempt at using the numeric keypad on mobile devices, but could not figure out how to do it without setting the type of the field to `number`...which doesn't work because we put things _other_ than numbers into it on the users behalf. Ideally we'd be able to show the numeric keyboard, but...eh.